### PR TITLE
Issue warning when catalog is too old

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -69,7 +69,7 @@ result () {
     4) echo "CRITICAL: Puppet daemon not running or something wrong with process";rc=2 ;;
     5) echo "UNKNOWN: no WARN or CRIT parameters were sent to this check";rc=3 ;;
     6) echo "CRITICAL: Last run had 1 or more errors. Check the logs";rc=2 ;;
-    7) echo "WARNING: Catalog at ${config_human} is too old" ;rc=2 ;;
+    7) echo "WARNING: Catalog at ${config_human} is too old" ;rc=1 ;;
   esac
   exit $rc
 }


### PR DESCRIPTION
In case the Puppet agent fails to retrieve a new catalog because of some configuration error, it uses a cached version:

```
Dec  9 08:55:44 lb2 puppet-agent[21605]: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: ...
Dec  9 08:55:45 lb2 puppet-agent[21605]: Using cached catalog
Dec  9 08:56:03 lb2 puppet-agent[21605]: Finished catalog run in 16.48 seconds
```

However, check_puppet_agent fails to notice this problem and reports OK. Proposed a fix so it issues a warning after -w WARNING seconds.
