### PR TITLE
last_run_report checked only if needed

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -240,7 +240,7 @@ splay=$($puppet_config_print splay)
 # If the lastrunreport is not given as a param try to find it ourselves.
 [ -z "$lastrunreport" ] && lastrunreport=$($puppet_config_print lastrunreport)
 # Check if state file exists.
-[ -s $lastrunreport -a -r $lastrunreport ] || result 12
+[ -n "$SHOW_ERROR" ] && ( [ -s $lastrunreport -a -r $lastrunreport ] || result 12 )
 
 # Check if daemonized was set, else set default to 1.
 [ -n "$daemonized" ] || daemonized=1


### PR DESCRIPTION
As the last_run_report.yaml is needed only in case of show erros,
skip file read check if not needed.

word of warning: https://projects.puppetlabs.com/issues/15471
https://github.com/puppetlabs/puppet/commit/0f13cf5