### PR TITLE
Fix Permission denied @ dir_s_mkdir, return 12 in case of status not readable

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -149,6 +149,12 @@ get_first_error() {
 }
 
 # SCRIPT
+# Fix home directory if needed
+# On Gentoo otherwise we get
+# UNKNOWN: Internal error: Puppet version unknown from Error: Could not initialize global default settings: Permission denied @ dir_s_mkdir - /root/.puppetlabs
+# this happens because $HOME is not set to the user one
+export HOME=$(eval echo "~$(whoami)")
+#
 while getopts "c:d:l:s:r:w:v:PEh" opt; do
   case $opt in
     c)
@@ -252,6 +258,8 @@ splay=$(parse_puppet_config "splay")
 
 # If the lastrunreport is not given as a param try to find it ourselves.
 [ -z "$lastrunreport" ] && lastrunreport=$(parse_puppet_config "lastrunreport")
+# Check if the lastrunreport is readable
+[ -r "$lastrunreport" ] || result 12
 # Check if state file exists.
 [ -n "$SHOW_ERROR" ] && ( [ -s $lastrunreport -a -r $lastrunreport ] || result 12 )
 


### PR DESCRIPTION
In some distribution like Gentoo, nrpe HOME env is not correctly set.
puppet is relying on HOME to write the local cache.
This patch address always the HOME env set.

The return code 12 was not set in the proper way in case of wrong grep.
This patch address the issue.