### PR TITLE
Fix "Could not retrieve catalog" check

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -308,7 +308,7 @@ if [ -n "$SHOW_ERROR" ] ; then
 fi
 
 # If the last run failed to retrieve the catalog from the server
-grep -q 'message: "Could not retrieve catalog from remote server' $lastrunreport && result 13
+grep -q 'Could not retrieve catalog from remote server' $lastrunreport && result 13
 
 # Check when last run happened.
 last_run=$_time_last_run


### PR DESCRIPTION
On failure to get catalog, don't bother validating that it's in the `message` field to simplify the check. This fixes an issue in which multi-line YAML output would put `message:` and the `Could not retrieve catalog from remote server` error are split across different lines as part of a multi-line YAML block.