### PR TITLE
Discard puppet config logging output

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -82,6 +82,7 @@
 # 20160315  J. Yaworski Add -v, allowing to pass a version to compare
 # 20160815  L. Buriola  Add -E to show first error on output
 # 20170426  benwtr      Detect failure to retrieve catalog from server as a warning.
+# 20180324  deric       Discard puppet config error (logging) output
 
 # FUNCTIONS
 result () {
@@ -227,7 +228,7 @@ case $puppet_major_version in
     ;;
 esac
 
-puppet_config_output="$($puppet_config_print)"
+puppet_config_output="$($puppet_config_print 2> /dev/null)"
 # construct WARN and CRIT times based on runinterval plus a safety buffer
 # if they have not already been explicitly set
 runinterval=$(parse_puppet_config "runinterval")


### PR DESCRIPTION
Puppet agent `5.5.0` prints "info" output that complicates parsing output 

```
/opt/puppetlabs/bin/puppet config print --section agent --render-as console
Resolving settings from section 'agent' in environment 'production'
agent_catalog_run_lockfile = /opt/puppetlabs/puppet/cache/state/agent_catalog_run.lock
...
```
This PR discards messages printed to `stderr`.