### PR TITLE
Check for sudo

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -210,7 +210,7 @@ PATH="$PATH:/opt/puppetlabs/bin"
 # Find location of puppet executable.
 PUPPET=$(which puppet) || result 8
 # Check if sudo installed
-which sudo || result 14
+which sudo 1>/dev/null 2>&1 || result 14
 
 # Find out Puppet major version to determine configprint syntax.
 puppet_major_version=$($PUPPET -V|cut -d. -f1)

--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -100,6 +100,7 @@ result () {
    11) echo "INFO: Puppet agent is version $version, but should be $wanted_version. $PERF_DATA";rc=0 ;;
    12) echo "UNKNOWN: last_run_report.yaml not found, not readable or incomplete";rc=3 ;;
    13) echo "WARNING: Failed to retrieve catalog on last run.";rc=1 ;;
+   14) echo "UNKNOWN: No sudo executable found";rc=3 ;;
   esac
   exit $rc
 }
@@ -208,6 +209,8 @@ parse_puppet_config () {
 PATH="$PATH:/opt/puppetlabs/bin"
 # Find location of puppet executable.
 PUPPET=$(which puppet) || result 8
+# Check if sudo installed
+which sudo || result 14
 
 # Find out Puppet major version to determine configprint syntax.
 puppet_major_version=$($PUPPET -V|cut -d. -f1)


### PR DESCRIPTION
This patch checks if sudo is installed.

Without this patch, script fails with an useless error:
```
/opt/monitoring/check_puppet_agent.sh
/opt/monitoring/check_puppet_agent.sh: line 238: + : syntax error: operand expected (error token is "+ ")
```