### PR TITLE
Allow -p to be a list of primary interfaces

### DIFF
--- a/check_bond
+++ b/check_bond
@@ -30,6 +30,7 @@
 # This plugin defaults to bond0. If you have multiple bonds you can tell the script so by adding -i <if>.
 # It will also warn if the Currently Active Slave is not the expected primary interface,
 # the default primary interface is eth0, You can override this with -p <if>
+# -p can be a comma separated list like "-p eno49,eno50"
 
 #  if you have dont_blame_nrpe=1 set you can choose to
 #  command[check_bond]=/usr/lib/nagios/plugins/check_bond -i $ARG1$ -p $ARG2$
@@ -53,6 +54,7 @@
 # A.Swen  2011-09-07 Add support for other bond module than bond0 (defaults to bond0 however)
 # A.Swen  2013-10-11 Remove some obsolete stuff and make the script shorter
 # B.Potts 2017-01-16 Check and display expected primary interface on bond
+# J.Guldmyr 2018-09-25 Check for a list of primary interfaces instead of a single one
 #
 #
 # SETTINGS
@@ -113,7 +115,7 @@ rc=0
 # Inspect the state of the entire bond interface
 ifstate=$(${AWK} '/Currently Active Slave/ {print $4}' /proc/net/bonding/${if})
 [ "${ifstate}" = "None" ]&& result 6
-[ "${ifstate}" = "${pri}" ] || result 7 "${ifstate}"
+[[ "${pri}" =~ "${ifstate}" ]] || result 7 "${ifstate}"
 [ $rc -gt 0 ] && exit $rc
 
 # test state of each if in bond


### PR DESCRIPTION
Some example output:

<pre>
$ bash check_bond -p eno48,eno49,eno50
OK: - Bondingmode: Bonding Mode: fault-tolerance (active-backup), active
link: eno50

$ bash check_bond -p eno49,eno50
OK: - Bondingmode: Bonding Mode: fault-tolerance (active-backup), active
link: eno50

$ bash check_bond -p eno50
OK: - Bondingmode: Bonding Mode: fault-tolerance (active-backup), active
link: eno50

$ bash check_bond -p eno49
WARNING: Bondingmode: Bonding Mode: fault-tolerance (active-backup),
(unexpected) active link: eno50

$ bash check_bond -p eno48
WARNING: Bondingmode: Bonding Mode: fault-tolerance (active-backup),
(unexpected) active link: eno50
</pre>

Showing that

With this bond:
<pre>
$ cat /proc/net/bonding/bond0
Ethernet Channel Bonding Driver: v3.7.1 (April 27, 2011)

Bonding Mode: fault-tolerance (active-backup)
Primary Slave: None
Currently Active Slave: eno50
MII Status: up
MII Polling Interval (ms): 100
Up Delay (ms): 0
Down Delay (ms): 0

Slave Interface: eno49
MII Status: up
Speed: 10000 Mbps
Duplex: full
Link Failure Count: 2
Permanent HW addr: aa:qq:aa:aa:aa:a1
Slave queue ID: 0

Slave Interface: eno50
MII Status: up
Speed: 10000 Mbps
Duplex: full
Link Failure Count: 4
Permanent HW addr: aa:qq:aa:aa:aa:a2
Slave queue ID: 0

</pre>