### PR TITLE
check_puppet_agent: fixed get_first_error function and made it simpler

### DIFF
--- a/check_puppet_agent
+++ b/check_puppet_agent
@@ -144,9 +144,8 @@ parse_yaml () {
 
 # Get first error from last_run_report.yaml
 get_first_error() {
-  grep_cmd="/bin/grep -B 3 -A 1"
-  first_error_time=$($grep_cmd "status: failure" $lastrunreport | grep "time: " | sort -n | head -1)
-  first_error=$($grep_cmd "$first_error_time" $lastrunreport | grep "message: " | sed 's/.*message: //' | head -1)
+  grep_cmd="/bin/grep -B 4 -A 1 -m 1"
+  first_error=$($grep_cmd "status: failure" $lastrunreport | grep -A 2 "message: " | sed -E '/ +message: \|-/d;s/ +message: +//g' | sed -E 's/  +//g')
   echo "FIRST_ERROR ($first_error)"
 }
 


### PR DESCRIPTION
you dont need to use the time stemp for getting it again if you do a -m 1 for the grep which brings you the first result all the time.
Also on the message, puppet bring often more then one line for the error message and often its not in the same line as the "message: " string there I have added the -A 2 in the grep to cover such cases as well
also changed a bit the removal of the " messages: " to cover both (if the line is containing an error or not)
and at the end I just removed the duplicated spaces from the error message